### PR TITLE
Fix for Typescript Props

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -9,7 +9,7 @@ const defaultSerializers = SanityBlockContent.defaultSerializers
  *
  * @param {object} props
  * @param {object[]} props.content Array of portable text blocks
- * @param {string} props.className Optional className
+ * @param {string | undefined} props.className Optional className
  * @param {object} props.serializers Optional serialization overrides
  * @returns
  */

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -8,7 +8,7 @@ const defaultSerializers = SanityBlockContent.defaultSerializers
  * Renders an array of Portable Text blocks as React components.
  *
  * @param {object} props
- * @param {[object]} props.content Array of portable text blocks
+ * @param {object[]} props.content Array of portable text blocks
  * @param {string} props.className Optional className
  * @param {object} props.serializers Optional serialization overrides
  * @returns


### PR DESCRIPTION
Typescript seems to be more strict than jsdoc with how it interprets types. I made some adjustments that shouldn't allow typescript/vscode to better understand the requirements.

Converting `content: [object]` to `content: object[]`.
Typescript understands `[object]` as an array of one object. An array of objects should be expressed as `object[]`

Allowing the classname to be `undefined`.
Typescript will throw an error thinking that this is required.
