### PR TITLE
feat: Upgrade Typescript and Prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@sanity/block-content-to-react": "^2.0.0",
-    "esbuild": "^0.8.49",
+    "esbuild": "^0.8.57",
     "eslint": "^7.20.0",
     "eslint-config-prettier": "^7.2.0",
     "eslint-config-standard": "^16.0.2",
@@ -30,9 +30,9 @@
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
     "prettier": "^2.2.1",
-    "prop-types": "^15.7.2",
+    "prop-types": "^15.8.1",
     "react": "^17.0.1",
-    "typescript": "^4.1.5"
+    "typescript": "^4.5.5"
   },
   "scripts": {
     "prebuild": "tsc",


### PR DESCRIPTION
This should fix https://github.com/coreyward/react-portable-text/issues/16

Here is a snippet from the generated Typescript type file that is being generated. 
Note the ? identifier which makes the property optional. 

```
declare function PortableText({ content, className, serializers, dataset, projectId, ...additionalOptions }: {
    content: object[];
    dataset?: string;
    projectId?: string;
    className?: string;
    serializers?: object;
}): any;
```