### PR TITLE
Fixes a couple issues with unknownType and ignoreUnknownTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
     "dist/index.d.ts"
   ],
   "dependencies": {
-    "@sanity/block-content-to-react": "^2.0.0"
+    "@sanity/block-content-to-react": "^3.0.0"
   },
   "peerDependencies": {
     "react": ">16.8.0 || ^17.0.0"
   },
   "devDependencies": {
-    "@sanity/block-content-to-react": "^2.0.0",
+    "@sanity/block-content-to-react": "^3.0.0",
     "esbuild": "^0.8.57",
     "eslint": "^7.20.0",
     "eslint-config-prettier": "^7.2.0",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -13,6 +13,7 @@ const defaultSerializers = SanityBlockContent.defaultSerializers
  * @param {string} [props.projectId] Project ID of your sanity project
  * @param {string} [props.className] Optional className
  * @param {object} [props.serializers] Optional serialization overrides
+ * @param {boolean} [props.ignoreUnknownTypes] Optional flag specifying whether to ignore unknown types
  * @returns
  */
 const PortableText = ({
@@ -45,6 +46,7 @@ PortableText.propTypes = {
   className: PropTypes.string,
   projectId: PropTypes.string,
   dataset: PropTypes.string,
+  ignoreUnknownTypes: PropTypes.bool,
   serializers: PropTypes.shape({
     // Marks
     link: PropTypes.elementType,

--- a/yarn.lock
+++ b/yarn.lock
@@ -52,22 +52,22 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@sanity/block-content-to-hyperscript@^2.0.10":
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/@sanity/block-content-to-hyperscript/-/block-content-to-hyperscript-2.0.10.tgz#9cf805c5d2341d043bcab8b3740c9b3466b5ae6b"
-  integrity sha512-xT3iEmZkK0fvO5PDFpn9GMWGfvOopvbrRCBU48XxpFoTxRrfsHhxbRy8J0eND1HGXHUENkIKv5jbohtGd1MiVg==
+"@sanity/block-content-to-hyperscript@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sanity/block-content-to-hyperscript/-/block-content-to-hyperscript-3.0.0.tgz#a8437b608daac9b7cc4124c490d345fa84d4a267"
+  integrity sha512-uoXWLdFY5LqO8A9sFJqnZWWDCBC+0r3Egeh0bwKQ2EK2Vil5L40iJGNXMZhDB8BnvH+6B4155SU8Q3vY59T6pA==
   dependencies:
     "@sanity/generate-help-url" "^0.140.0"
     "@sanity/image-url" "^0.140.15"
     hyperscript "^2.0.2"
     object-assign "^4.1.1"
 
-"@sanity/block-content-to-react@^2.0.0":
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/@sanity/block-content-to-react/-/block-content-to-react-2.0.7.tgz#6e257b5ab59ebe406005032eea586391d963eb93"
-  integrity sha512-oSriTf/3Ihnxp6AjEGiVjNPA2Iq/IFaWg4Frn5msGq5GT8N1kwLwxduig1OSn87UA15LNwiai9LAJwBR2k9lIg==
+"@sanity/block-content-to-react@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sanity/block-content-to-react/-/block-content-to-react-3.0.0.tgz#1deac74763540fdf61b14ad52fb1a01b35d60453"
+  integrity sha512-oHPLlIsulsnL3ITs93RIvUPBI6nAeoSFOUf16vX4T7z4wWywxP39N1DF9mAx2tV6Kjr1fJAx5GF7zfiMXYLaqA==
   dependencies:
-    "@sanity/block-content-to-hyperscript" "^2.0.10"
+    "@sanity/block-content-to-hyperscript" "^3.0.0"
     prop-types "^15.6.2"
 
 "@sanity/generate-help-url@^0.140.0":


### PR DESCRIPTION
I recently ran into a couple issues with the `unknownType` serializer. From what I've been able to glean, I think the solutions included in this PR should address them, but let me know if there's anything I'm mistaken on or if anything needs to be changed.

#### `ignoreUnknownTypes` not defined in `PortableText` props
When trying to pass `props.ignoreUnknownTypes`, I was seeing a TypeScript error similar to the following (trimmed for brevity):

```
Type '{ ignoreUnknownTypes: boolean; ... 5 more ...; }' is not assignable to type '{ content: object[]; dataset?: string | undefined; ... 3 more ...; }'.
  Property 'ignoreUnknownTypes' does not exist on type '{ content: object[]; dataset?: string | undefined; ... 3 more ...; }'. ts(2322)
```

This is because there's no annotation for this prop, so the generated TypeScript definition lacks it as well. This was kind of unexpected since the docs mention it alongside `unknownType`, and also [say that additional props are passed through](https://github.com/coreyward/react-portable-text#additional-props). 

This PR fixes the TypeScript error by [adding an annotation and optional prop type for `ignoreUnknownTypes`](https://github.com/coreyward/react-portable-text/commit/b837fbe2583cbd08490043352ce4dd292a117b4e).

#### `unknownTypes` and `ignoreUnknownTypes` aren't being used at runtime
Despite specifying an `unknownType` serializer and toggling `ignoreUnknownTypes`, the serializer wasn't being invoked and the default exception was still being raised. I think this is due to the fact that support for these properties wasn't added to `@sanity/block-content-to-react` until 3.0.0. Testing with `@sanity/block-content-to-react@^3.0.0` fixes this issue for me locally, so this PR [includes that update](https://github.com/coreyward/react-portable-text/commit/605a93624af124415d6e141e8e5c9cc8de6a153e).