### PR TITLE
Changes content's prop type to accept an object or array of objects

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -8,7 +8,7 @@ const defaultSerializers = SanityBlockContent.defaultSerializers
  * Renders an array of Portable Text blocks as React components.
  *
  * @param {object} props
- * @param {object[]} props.content Array of portable text blocks
+ * @param {object|object[]} props.content Array of portable text blocks
  * @param {string} [props.dataset] Dataset for your sanity project
  * @param {string} [props.projectId] Project ID of your sanity project
  * @param {string} [props.className] Optional className
@@ -42,7 +42,10 @@ const PortableText = ({
 export default PortableText
 
 PortableText.propTypes = {
-  content: PropTypes.array.isRequired,
+  content: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.arrayOf(PropTypes.object),
+  ]).isRequired,
   className: PropTypes.string,
   projectId: PropTypes.string,
   dataset: PropTypes.string,


### PR DESCRIPTION
Recently we've noticed the following error in some of our logs:

```
Warning: Failed prop type: Invalid prop `content` of type `object` supplied to `q`, expected `array`.
    at q (webpack-internal:///./node_modules/react-portable-text-dist/index.js:1:1229)
    at PortableText
    at Page (webpack-internal:///./pages/[...slug].tsx:130:20)
    at div
    (...)
```

I realized that we were passing an object into `<PortableText />` for the content prop, instead of an array which the component's prop types expects. However I was a bit confused because nothing was affected at runtime and it worked as expected (we've only been seeing this message in our build pipeline).

I double checked `@sanity/block-content-to-react` and found that [it accepts either the array or a single block object](https://github.com/sanity-io/block-content-to-react/blob/main/src/BlockContent.js#L53), which I guess explains that part.

Feel free to close this PR if narrowing the type down to just the array of objects was intentional, just wanted to throw this out there in case it's helpful. On our end it would be just as easy for us to update our implementation so that it passes an array, so either way is fine for us.