### PR TITLE
Memoize serializers

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -25,7 +25,10 @@ const PortableText = ({
   ...additionalOptions
 }) => {
   if (!content) throw new Error("No `content` provided to PortableText.")
-  const memoizedSerializer = useMemo(() => buildSerializer(serializers), [serializers])
+  const memoizedSerializer = useMemo(
+    () => buildSerializer(serializers),
+    [serializers]
+  )
 
   return (
     <SanityBlockContent

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useMemo } from "react"
 import PropTypes from "prop-types"
 import SanityBlockContent from "@sanity/block-content-to-react"
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -25,12 +25,13 @@ const PortableText = ({
   ...additionalOptions
 }) => {
   if (!content) throw new Error("No `content` provided to PortableText.")
+  const memoizedSerializer = useMemo(() => buildSerializer(serializers), [serializers])
 
   return (
     <SanityBlockContent
       blocks={content}
       className={className}
-      serializers={buildSerializer(serializers)}
+      serializers={memoizedSerializer}
       renderContainerOnSingleChild
       dataset={dataset}
       projectId={projectId}


### PR DESCRIPTION
I came across an issue where toggling state in an ``_app.jsx`` component through context would make the ``<PortableText>`` component completely re-mount.

Presumably this was caused by the serializers being rebuilt on each render, making the blocks inside of ``<PortableText>`` remount.

Memoizing the serializers has fixed this.